### PR TITLE
Initial Python 2.7 compatibility patch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,5 @@ language: python
 python:
 - 3.6
 - 3.5
+- 2.7
 script: tox

--- a/drf_openapi/entities.py
+++ b/drf_openapi/entities.py
@@ -42,12 +42,12 @@ class VersionedSerializers:
         ('>1.3, <=1.6', MeSerializer16)
         ('>1.6', MeSerializer)
     )
-    
+
     """
     VERSION_MAP = ()
 
     @classmethod
-    def get(cls, request_version: str):
+    def get(cls, request_version):
         for allowed_version, schema in cls.VERSION_MAP:
             distinct_versions = [version.strip() for version in allowed_version.split(',')]
             matched = True
@@ -73,7 +73,8 @@ class VersionedSerializers:
             if matched:
                 return schema
 
-        raise ValueError(f'Invalid request version {request_version}')
+        raise ValueError('Invalid request version {}'.format(request_version))
+    get.__func__.__annotations__ = {'request_version': str}
 
 
 class OpenApiSchemaGenerator(SchemaGenerator):

--- a/drf_openapi/urls.py
+++ b/drf_openapi/urls.py
@@ -2,5 +2,5 @@ from django.conf.urls import url, include
 
 from drf_openapi.views import get_schema_view
 urlpatterns = [
-    url(f'schema/$', get_schema_view(url='', title="API Documentation"), name='api_schema')
+    url('schema/$', get_schema_view(url='', title="API Documentation"), name='api_schema')
 ]

--- a/drf_openapi/utils.py
+++ b/drf_openapi/utils.py
@@ -6,8 +6,8 @@ from drf_openapi.entities import VersionedSerializers
 from rest_framework.response import Response
 
 
-def view_config(request_serializer=None, response_serializer=None, validate_response=False) -> Callable:
-    def decorator(view_method: Callable) -> Callable:
+def view_config(request_serializer=None, response_serializer=None, validate_response=False):
+    def decorator(view_method):
 
         view_method.request_serializer = request_serializer
         view_method.response_serializer = response_serializer
@@ -33,4 +33,6 @@ def view_config(request_serializer=None, response_serializer=None, validate_resp
             return response
 
         return wrapper
+    decorator.__annotations__ = {'view_method': Callable, 'return': Callable}
     return decorator
+view_config.__annotations__ = {'return': Callable}

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,8 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,11 @@
 [tox]
-envlist = py35, py36, flake8
+envlist = py27, py35, py36, flake8
 
 [travis]
 python =
     3.6: py36
     3.5: py35
+    2.7: py27
 
 [testenv:flake8]
 basepython=python


### PR DESCRIPTION
This patch adds Python 2.7 compatibility. It removes f-string usage and adds a compatibility workaround for type hints.