### PR TITLE
Various bug fixes/improvements for schema generation.

### DIFF
--- a/drf_openapi/codec.py
+++ b/drf_openapi/codec.py
@@ -133,7 +133,7 @@ def _get_field_type(field):
     if field.__class__ in type_name_map:
         return type_name_map[field.__class__]
 
-    if field.schema is None:
+    if getattr(field, 'schema', None) is None:
         return 'string'
 
     return type_name_map.get(field.schema.__class__, 'string')

--- a/drf_openapi/entities.py
+++ b/drf_openapi/entities.py
@@ -319,11 +319,17 @@ class OpenApiSchemaGenerator(SchemaGenerator):
         nested_obj = {}
 
         for field in serializer.fields.values():
+            # If field is a serializer, attempt to get its schema.
             if isinstance(field, serializers.Serializer):
-                nested_obj[field.field_name] = self.get_response_object(field.__class__, None)[0]['schema']
-                nested_obj[field.field_name]['description'] = field.help_text
-                continue
+                subfield_schema = self.get_response_object(field.__class__, None)[0].get('schema')
 
+                # If the schema exists, use it as the nested_obj
+                if subfield_schema is not None:
+                    nested_obj[field.field_name] = subfield_schema
+                    nested_obj[field.field_name]['description'] = field.help_text
+                    continue
+
+            # Otherwise, carry-on and use the field's schema.
             fields.append(Field(
                 name=field.field_name,
                 location='form',

--- a/drf_openapi/utils.py
+++ b/drf_openapi/utils.py
@@ -13,7 +13,7 @@ def view_config(request_serializer=None, response_serializer=None, validate_resp
         view_method.response_serializer = response_serializer
 
         @wraps(view_method)
-        def wrapper(instance, request, version, *args, **kwargs):
+        def wrapper(instance, request, version=None, *args, **kwargs):
             if request_serializer and issubclass(request_serializer, VersionedSerializers):
                 instance.request_serializer = request_serializer.get(version)
             else:
@@ -24,7 +24,7 @@ def view_config(request_serializer=None, response_serializer=None, validate_resp
             else:
                 instance.response_serializer = response_serializer
 
-            response = view_method(instance, request, version, *args, **kwargs)
+            response = view_method(instance, request, version=version, *args, **kwargs)
             if validate_response:
                 response_validator = instance.response_serializer(data=response.data)
                 response_validator.is_valid(raise_exception=True)


### PR DESCRIPTION
These are fixes I made based on `drf_openapi==0.9.6` adapting a fairly large Django/DRF application. For reference, the application I'm attempting to update is one I maintain called NSoT
 (Source: https://github.com/dropbox/nsot)

- Bugfix in `codec._get_field_type`: Changed `field.schema` lookup to a `getattr(field, 'schema', None)` to fix an `AttributeError` crash for custom fields that don't have correct schema mappings but should still default sanely to `string` type.
- Bugfix in `entities.OpenAPISchemaGenerator.get_response_object` fixing a `KeyError` that would occur when a serializer field-type has no resultant response serializer class, causing it to not have a
  `schema` key.
- Improve `utils.view_config` to expect and pass `version` as a kwarg so that existing projects don't need to refactor *every single view method* to support a positional `version` arg.