### PR TITLE
[WIP] [DO NOT MERGE] Fix DRF 3.7 compatibility

### DIFF
--- a/drf_openapi/entities.py
+++ b/drf_openapi/entities.py
@@ -12,7 +12,10 @@ from pkg_resources import parse_version
 from rest_framework import serializers
 from rest_framework.fields import IntegerField, URLField
 from rest_framework.pagination import PageNumberPagination, LimitOffsetPagination, CursorPagination
-from rest_framework.schemas import SchemaGenerator, insert_into, get_pk_description, field_to_schema
+from rest_framework.schemas import SchemaGenerator
+from rest_framework.schemas.generators import insert_into
+from rest_framework.schemas.inspectors import get_pk_description, field_to_schema
+from rest_framework.schemas.utils import is_list_view
 
 from drf_openapi.codec import _get_parameters
 


### PR DESCRIPTION
This is the start of #64. This only fixes imports but there were some breaking interface changes that will require updates to `OpenApiSchemaGenerator`.

Verified that the imports work, but you will still get an unhandled exception when visiting the schema endpoint:

```python
Traceback (most recent call last):
  File "/Users/sloria/.local/share/virtualenvs/til/lib/python3.6/site-packages/django/core/handlers/exception.py", line 41, in inner
    response = get_response(request)
  File "/Users/sloria/.local/share/virtualenvs/til/lib/python3.6/site-packages/django/core/handlers/base.py", line 187, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/Users/sloria/.local/share/virtualenvs/til/lib/python3.6/site-packages/django/core/handlers/base.py", line 185, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/local/Cellar/python3/3.6.3/Frameworks/Python.framework/Versions/3.6/lib/python3.6/contextlib.py", line 52, in inner
    return func(*args, **kwds)
  File "/Users/sloria/.local/share/virtualenvs/til/lib/python3.6/site-packages/django/views/decorators/csrf.py", line 58, in wrapped_view
    return view_func(*args, **kwargs)
  File "/Users/sloria/.local/share/virtualenvs/til/lib/python3.6/site-packages/django/views/generic/base.py", line 68, in view
    return self.dispatch(request, *args, **kwargs)
  File "/Users/sloria/.local/share/virtualenvs/til/lib/python3.6/site-packages/rest_framework/views.py", line 489, in dispatch
    response = self.handle_exception(exc)
  File "/Users/sloria/.local/share/virtualenvs/til/lib/python3.6/site-packages/rest_framework/views.py", line 449, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/Users/sloria/.local/share/virtualenvs/til/lib/python3.6/site-packages/rest_framework/views.py", line 486, in dispatch
    response = handler(request, *args, **kwargs)
  File "/Users/sloria/projects/django-projects/drf_openapi/drf_openapi/views.py", line 22, in get
    return response.Response(generator.get_schema(request))
  File "/Users/sloria/projects/django-projects/drf_openapi/drf_openapi/entities.py", line 97, in get_schema
    links = self.get_links(None if public else request)
  File "/Users/sloria/projects/django-projects/drf_openapi/drf_openapi/entities.py", line 137, in get_links
    link = self.get_link(path, method, view, version=request.version)
  File "/Users/sloria/projects/django-projects/drf_openapi/drf_openapi/entities.py", line 158, in get_link
    fields += self.get_pagination_fields(path, method, view)
AttributeError: 'OpenApiSchemaGenerator' object has no attribute 'get_pagination_fields'
```