### PR TITLE
Default version to None if request does not exist.

### DIFF
--- a/drf_openapi/entities.py
+++ b/drf_openapi/entities.py
@@ -131,7 +131,7 @@ class OpenApiSchemaGenerator(SchemaGenerator):
         for path, method, view in view_endpoints:
             if not self.has_view_permissions(path, method, view):
                 continue
-            link = self.get_link(path, method, view, version=request.version)
+            link = self.get_link(path, method, view, version=getattr(request, 'version', None))
             subpath = path[len(prefix):]
             keys = self.get_keys(subpath, method, view)
             try:


### PR DESCRIPTION
When public=True is passed into get_schema() the request object 
does not get passed on to get_links(). This causes an issue when
request.version is called.