### PR TITLE
Make DRF API versioning optional.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ This project was born to bridge the gap between DRF and OpenAPI. The high-level 
 
 - Can be dropped into any existing DRF project without any code change necessary.
 - Provide clear disctinction between request schema and response schema.
-- Provide a versioning mechanism for each schema. Support defining schema by version range syntax, e.g. :code:`>1.0, <=2.0`
+- If desired, provide a versioning mechanism for each schema. Support defining schema by version range syntax, e.g. :code:`>1.0, <=2.0`
 - Support multiple response codes, not just :code:`200`
 - All this information should be bound to view methods, not view classes.
 
@@ -67,8 +67,8 @@ DRF itself decides to support OpenAPI officially, if at all.
 4. Constraints
 ----------------
 
-Currently DRF OpenAPI only supports DRF project that has `versioning <http://www.django-rest-framework.org/api-guide/versioning/#urlpathversioning>`_ enabled.
-I have only tested `URLPathVersioning <http://www.django-rest-framework.org/api-guide/versioning/#urlpathversioning>`_ but I intend to suppor the full range of
+DRF OpenAPI supports DRF projects both with and without `versioning <http://www.django-rest-framework.org/api-guide/versioning/#urlpathversioning>`_ enabled.
+That said, I have only tested `URLPathVersioning <http://www.django-rest-framework.org/api-guide/versioning/#urlpathversioning>`_ but I intend to support the full range of
 versioning scheme supported by DRF.
 
 5. Examples

--- a/drf_openapi/entities.py
+++ b/drf_openapi/entities.py
@@ -192,10 +192,13 @@ class OpenApiSchemaGenerator(SchemaGenerator):
         response_schema, error_status_codes = self.get_response_object(
             response_serializer_class, method_func.__doc__) if response_serializer_class else ({}, {})
 
+        url = path
+        if self.version:
+            url = path.replace('{version}', self.version)  # can't use format because there may be other param
         return OpenApiLink(
             response_schema=response_schema,
             error_status_codes=error_status_codes,
-            url=path.replace('{version}', self.version),  # can't use format because there may be other param
+            url=url,
             action=method.lower(),
             encoding=encoding,
             fields=fields,

--- a/drf_openapi/templates/drf_openapi/index.html
+++ b/drf_openapi/templates/drf_openapi/index.html
@@ -9,10 +9,20 @@
             margin: 0;
             padding: 0;
         }
+        {% if not request.version %}
+        span.api-info-version {
+            display: none;
+        }
+        {% endif %}
     </style>
 </head>
 <body>
-    <redoc spec-url='{% url 'api_schema' version=request.version %}?format=openapi'></redoc>
+    <script>
+        var url = window.location.pathname + '?format=openapi';
+        var redoc = document.createElement("redoc");
+        redoc.setAttribute("spec-url", url);
+        document.body.appendChild(redoc);
+    </script>
     <script src="https://rebilly.github.io/ReDoc/releases/latest/redoc.min.js"> </script>
 </body>
 </html>

--- a/drf_openapi/views.py
+++ b/drf_openapi/views.py
@@ -13,7 +13,7 @@ class SchemaView(APIView):
     url = ''
     title = 'API Documentation'
 
-    def get(self, request, version):
+    def get(self, request, version=''):
         generator = OpenApiSchemaGenerator(
             version=version,
             url=self.url,


### PR DESCRIPTION
Make drf-openapi work without enabling api versioning (i.e. without having a `version` parameter in the request).

Motivation:
* not all users have versioning enabled
* it is not always easy, desired or even possible to enable versioning
* the readme claims that this "Can be dropped into any existing DRF project without any code change necessary."

Closes #71.