### PR TITLE
Fix #105: Use Django's force_text to handle gettext proxy objects

### DIFF
--- a/drf_openapi/entities.py
+++ b/drf_openapi/entities.py
@@ -5,7 +5,7 @@ from collections import OrderedDict
 import coreschema
 import uritemplate
 from coreapi import Link, Document, Field
-from coreapi.compat import force_text
+from django.utils.encoding import force_text
 from django.db import models
 from django.utils.functional import Promise
 from pkg_resources import parse_version


### PR DESCRIPTION
This PR fixes #105.