### PR TITLE
improve versioning schemes support

### DIFF
--- a/drf_openapi/utils.py
+++ b/drf_openapi/utils.py
@@ -13,7 +13,9 @@ def view_config(request_serializer=None, response_serializer=None, validate_resp
         view_method.response_serializer = response_serializer
 
         @wraps(view_method)
-        def wrapper(instance, request, version=None, *args, **kwargs):
+        def wrapper(instance, request, *args, **kwargs):
+            version, _ = instance.determine_version(request, *args, **kwargs)
+
             if request_serializer and issubclass(request_serializer, VersionedSerializers):
                 instance.request_serializer = request_serializer.get(version)
             else:
@@ -24,7 +26,7 @@ def view_config(request_serializer=None, response_serializer=None, validate_resp
             else:
                 instance.response_serializer = response_serializer
 
-            response = view_method(instance, request, version=version, *args, **kwargs)
+            response = view_method(instance, request, *args, **kwargs)
             if validate_response:
                 response_validator = instance.response_serializer(data=response.data)
                 response_validator.is_valid(raise_exception=True)

--- a/drf_openapi/views.py
+++ b/drf_openapi/views.py
@@ -13,7 +13,8 @@ class SchemaView(APIView):
     url = ''
     title = 'API Documentation'
 
-    def get(self, request, version):
+    def get(self, request, *args, **kwargs):
+        version, _ = self.determine_version(request, *args, **kwargs)
         generator = OpenApiSchemaGenerator(
             version=version,
             url=self.url,

--- a/examples/snippets/views.py
+++ b/examples/snippets/views.py
@@ -28,7 +28,7 @@ class SnippetList(APIView):
     """
 
     @view_config(response_serializer=SnippetSerializer)
-    def get(self, request, version, format=None):
+    def get(self, request, version=None, format=None):
         res = self.response_serializer(data=_FAKE_SNIPPETS, many=True)
         res.is_valid(raise_exception=True)
         return Response(res.validated_data)


### PR DESCRIPTION
close #98

view_config decorator now gets version using determine_version method of ApiView (vs version keyword argument which is not set eg. with AcceptHeaderVersioning)

close #71

with this schemes support improvement, drf_openapi's urls can be imported without a version parameter in url if REST_FRAMEWORK['DEFAULT_VERSION'] is set